### PR TITLE
added a method to return the compression count

### DIFF
--- a/lib/Tinify/Result.php
+++ b/lib/Tinify/Result.php
@@ -33,4 +33,8 @@ class Result extends ResultMeta {
     public function contentType() {
         return $this->mediaType();
     }
+    
+    public function compressionCount() {
+        return $this->meta['compression-count'];
+    }
 }


### PR DESCRIPTION
The Result returns a header containing the current compression-count, rather than doing a separate cURL request to get this in your code, you can simply extract this header. As the properties are all protected they cannot be accessed outside without this local method.