### PR TITLE
Version of lib-curl degraded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": ">=5.3.0",
     "ext-curl": "*",
     "ext-json": "*",
-    "lib-curl": ">=7.20.0"
+    "lib-curl": ">=7.19.0"
   },
 
   "require-dev": {


### PR DESCRIPTION
In composer, you have added min version of lib-curl to be 7.20 but redhat system's latest lib-curl is 7.19
I used same code without composer on 7.19 lib-curl linux distribution, and it works fine for me without any changes in the source code.