### PR TITLE
PSR-4 autoloading only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
   },
 
   "autoload": {
-    "files": ["lib/Tinify.php", "lib/Tinify/Exception.php"],
     "psr-4": {"Tinify\\": "lib/Tinify/"}
   }
 }

--- a/lib/Tinify/AccountException.php
+++ b/lib/Tinify/AccountException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tinify;
+
+class AccountException extends Exception {}

--- a/lib/Tinify/ClientException.php
+++ b/lib/Tinify/ClientException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tinify;
+
+class ClientException extends Exception {}

--- a/lib/Tinify/ConnectionException.php
+++ b/lib/Tinify/ConnectionException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tinify;
+
+class ConnectionException extends Exception {}

--- a/lib/Tinify/Exception.php
+++ b/lib/Tinify/Exception.php
@@ -29,8 +29,3 @@ class Exception extends \Exception {
         }
     }
 }
-
-class AccountException extends Exception {}
-class ClientException extends Exception {}
-class ServerException extends Exception {}
-class ConnectionException extends Exception {}

--- a/lib/Tinify/ServerException.php
+++ b/lib/Tinify/ServerException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tinify;
+
+class ServerException extends Exception {}


### PR DESCRIPTION
Since it looks like you are maintaining this package, I thought I would submit a PR to upgrade to full PSR-4 autoloading.

There is no need for a "files" section, PSR-4 gets it done when you do one class per file.  This PR simply breaks up the Exceptions into individual files and removes the "files" section from the autoloader.

This allows for super fast autoloaders and is considered best practice in PHP.

Thanks!