### PR TITLE
String interpolation update

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -16,7 +16,7 @@ jobs:
           "5.6",
           "7.4",
           "8.0",
-          "8.1",
+          "8.2",
         ]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
@@ -41,7 +41,7 @@ jobs:
       matrix:
         php-version: [
           "7.4",
-          "8.1",
+          "8.2",
         ]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 1.6.1
+Fixed string interpolation for php 8.2: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
+
 ## 1.6.0
 * Support to run the unittests on newer versions of PHP (5.5 +)
 * Add API methods for converting/transcoding and transformation

--- a/lib/Tinify.php
+++ b/lib/Tinify.php
@@ -2,7 +2,7 @@
 
 namespace Tinify;
 
-const VERSION = "1.6.0";
+const VERSION = "1.6.1";
 
 class Tinify {
     private static $key = NULL;

--- a/lib/Tinify/Client.php
+++ b/lib/Tinify/Client.php
@@ -28,7 +28,7 @@ class Client {
 
         if ($curl["version_number"] < 0x071201) {
             $version = $curl["version"];
-            throw new ClientException("Your curl version ${version} is outdated; please upgrade to 7.18.1 or higher");
+            throw new ClientException("Your curl version {$version} is outdated; please upgrade to 7.18.1 or higher");
         }
 
         $this->options = array(


### PR DESCRIPTION
This change changes the string interpolation syntax as mentioned in issue #34 (PHP 8.2: Deprecated ${} string interpolation.)

We also update the test runner from PHP 8.1 to 8.2