### PR TITLE
Use HTTP Post when retrieving result

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 1.6.4
+* Will use POST instead of GET when retrieving result.
+
 ## 1.6.3
 * Add minimum TLS 1.2 version to curl options as protocol negotiation on certain openssl/libcurl versions is flaky.
 

--- a/lib/Tinify.php
+++ b/lib/Tinify.php
@@ -2,7 +2,7 @@
 
 namespace Tinify;
 
-const VERSION = "1.6.3";
+const VERSION = "1.6.4";
 
 class Tinify {
     private static $key = NULL;

--- a/lib/Tinify/Source.php
+++ b/lib/Tinify/Source.php
@@ -53,7 +53,7 @@ class Source {
     }
 
     public function result() {
-        $response = Tinify::getClient()->request("get", $this->url, $this->commands);
+        $response = Tinify::getClient()->request("post", $this->url, $this->commands);
         return new Result($response->headers, $response->body);
     }
 


### PR DESCRIPTION
When fetching the result of a compression, users call the method result(). This will do a request to an url like:
`https://api.tinify.com/output/<randomstring>`
This will resolve to a file. 

Because it is possible to add commands to this request such as and other commands, the result would be a `GET` request with a body. Although this is possible, it is not recommended.

Therefor we should change the method to a POST. Shouldn't be a breaking change so patched the version.