### PR TITLE
phpstan level 5

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -1,0 +1,21 @@
+---
+name: PHPStan
+
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+          tools: composer:v2
+      - name: Install Dependencies
+        run: composer install --no-ansi --no-interaction --no-progress
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -16,6 +16,6 @@ jobs:
           php-version: "7.4"
           tools: composer:v2
       - name: Install Dependencies
-        run: composer install --no-ansi --no-interaction --no-progress
+        run: COMPOSER=composer.phpstan.json composer install --no-ansi --no-interaction --no-progress
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse
+        run: vendor-phpstan/bin/phpstan analyse

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor
+vendor-phpstan
 .phpunit.result.cache
 composer.lock
+composer.phpstan.lock

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
   },
 
   "require-dev": {
-    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4 || ^9.3"
+    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4 || ^9.3",
+    "phpstan/phpstan": "^2.1"
   },
 
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
   },
 
   "require-dev": {
-    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4 || ^9.3",
-    "phpstan/phpstan": "^2.1"
+    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4 || ^9.3"
   },
 
   "autoload": {

--- a/composer.phpstan.json
+++ b/composer.phpstan.json
@@ -1,0 +1,9 @@
+{
+  "description": "composer for PHPStan to still support php5.4 and higher in the main composer file",
+  "config": {
+    "vendor-dir": "vendor-phpstan"
+  },
+  "require": {
+    "phpstan/phpstan": "^2.1"
+  }
+}

--- a/lib/Tinify.php
+++ b/lib/Tinify.php
@@ -53,15 +53,15 @@ class Tinify {
 }
 
 function setKey($key) {
-    return Tinify::setKey($key);
+    Tinify::setKey($key);
 }
 
 function setAppIdentifier($appIdentifier) {
-    return Tinify::setAppIdentifier($appIdentifier);
+    Tinify::setAppIdentifier($appIdentifier);
 }
 
 function setProxy($proxy) {
-    return Tinify::setProxy($proxy);
+    Tinify::setProxy($proxy);
 }
 
 function getCompressionCount() {

--- a/lib/Tinify/Client.php
+++ b/lib/Tinify/Client.php
@@ -87,7 +87,7 @@ class Client {
             }
 
             $request = curl_init();
-            if ($request === false || $request === null) {
+            if ($request === false) {
                 throw new ConnectionException(
                     "Error while connecting: curl extension is not functional or disabled."
                 );

--- a/lib/Tinify/Client.php
+++ b/lib/Tinify/Client.php
@@ -153,6 +153,7 @@ class Client {
                 throw new ConnectionException("Error while connecting: " . $message);
             }
         }
+        throw new ConnectionException("Error while connecting: max retries exceeded");
     }
 
     protected static function parseHeaders($headers) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    phpVersion: 70100
+    level: 4
+    paths:
+        - lib

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
     phpVersion: 70100
-    level: 4
+    level: 5
     paths:
         - lib


### PR DESCRIPTION
added workflow for phpstan analysis.

- set current standard to level 5 (https://phpstan.org/user-guide/rule-levels). Level 5 only required one fix
- level 6 requires 93 fixes which is to much for this PR
- added it as 2nd workflow as it can run independent
- targets min version 7